### PR TITLE
macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.d
 *.gb
 main
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,15 @@ OBJS_LIBRETRO := $(patsubst %.o,obj_libretro/%.o,$(OBJS) $(OBJS_LIBRETRO))
 CC = clang
 RM = rm -fv
 
+SDL2_CFLAGS  := $(shell pkg-config --cflags sdl2)
+SDL2_LDFLAGS := $(shell pkg-config --libs sdl2)
+
 W_FLAGS = -Wall -Wextra -Werror-implicit-function-declaration -Wshadow
-CFLAGS = -MD -std=c11 -g3 -O0 $(W_FLAGS)
+CFLAGS = -MD -std=c11 -g3 -O0 $(W_FLAGS) $(SDL2_CFLAGS)
 CFLAGS_STANDALONE =
 CFLAGS_LIBRETRO = -fPIC
 
-LDFLAGS = -g3
+LDFLAGS = -g3 $(SDL2_LDFLAGS)
 LDFLAGS_STANDALONE = -lSDL2 -lreadline
 LDFLAGS_LIBRETRO = -fPIC -shared
 

--- a/debugger.c
+++ b/debugger.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <readline/readline.h>
 #include <readline/history.h>
 
@@ -28,8 +29,8 @@ int dbg_run_debugger(struct gb_state *s) {
 
         /* Copy into buffer that is automatically free'd on function exit. */
         char input[32];
-        strncpy(input, raw_input, 32);
-        input[31] = '\0';
+        strncpy(input, raw_input, sizeof(input));
+        input[sizeof(input) - 1] = '\0';
         free(raw_input);
 
         if (strlen(input) == 0) {


### PR DESCRIPTION
## Changes
- add `SDL2_CFLAGS` and `SDL2_LDFLAGS`
- ignore `.vscode` folder
- fix: strncpy(input, raw_input, sizeof(input));

## Tested on macOS arm64

https://github.com/user-attachments/assets/02150769-9a65-4a7d-b08f-a2d5b9e696b2

